### PR TITLE
値リストにコンマをエスケープ入力できるように

### DIFF
--- a/extension/src/mock/valueList.ts
+++ b/extension/src/mock/valueList.ts
@@ -1,0 +1,34 @@
+export function parseValueList(input: string): string[] {
+  const tokens: string[] = [];
+  let buf = '';
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (ch === '\\') {
+      const next = input[i + 1];
+      if (next === undefined) {
+        buf += '\\';
+      } else {
+        buf += next;
+        i++;
+      }
+      continue;
+    }
+    if (ch === ',') {
+      tokens.push(buf);
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  tokens.push(buf);
+  return tokens.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+export function serializeValueList(values: ReadonlyArray<string | number | boolean | null>): string {
+  return values
+    .map((v) => {
+      if (v === null) return '';
+      return String(v).replace(/\\/g, '\\\\').replace(/,/g, '\\,');
+    })
+    .join(', ');
+}

--- a/extension/test/valueList.test.ts
+++ b/extension/test/valueList.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { parseValueList, serializeValueList } from '../src/mock/valueList.js';
+
+describe('Issue reproduction: 値リストにコンマを入力できない', () => {
+  it('\\, でエスケープされたコンマは値の一部として扱われる', () => {
+    expect(parseValueList('hello\\, world, foo, bar\\, baz')).toEqual([
+      'hello, world',
+      'foo',
+      'bar, baz',
+    ]);
+  });
+
+  it('単一の値が "," のみの場合: \\, を入力すると ["",] ではなく [","]', () => {
+    expect(parseValueList('\\,')).toEqual([',']);
+  });
+
+  it('serialize → parse のラウンドトリップでコンマ含む値が保持される', () => {
+    const values = ['hello, world', 'foo', 'a,b,c'];
+    expect(parseValueList(serializeValueList(values))).toEqual(values);
+  });
+
+  it('serializeValueList: 値内のコンマを \\, に、バックスラッシュを \\\\ にエスケープ', () => {
+    expect(serializeValueList(['a, b', 'c\\d'])).toBe('a\\, b, c\\\\d');
+  });
+});
+
+describe('parseValueList - 既存挙動の維持', () => {
+  it('単純なカンマ区切り', () => {
+    expect(parseValueList('A, B, C')).toEqual(['A', 'B', 'C']);
+  });
+
+  it('前後の空白はトリム', () => {
+    expect(parseValueList('  foo  ,  bar  ')).toEqual(['foo', 'bar']);
+  });
+
+  it('空トークンは除外', () => {
+    expect(parseValueList('a,,b')).toEqual(['a', 'b']);
+    expect(parseValueList(',a,')).toEqual(['a']);
+  });
+
+  it('空文字列は空配列', () => {
+    expect(parseValueList('')).toEqual([]);
+    expect(parseValueList('   ')).toEqual([]);
+  });
+});
+
+describe('parseValueList - バックスラッシュエスケープの詳細', () => {
+  it('\\\\ はリテラル \\ になる', () => {
+    expect(parseValueList('a\\\\b')).toEqual(['a\\b']);
+  });
+
+  it('\\\\, は リテラル \\ の後に区切りコンマ', () => {
+    expect(parseValueList('a\\\\, b')).toEqual(['a\\', 'b']);
+  });
+
+  it('末尾の単独 \\ はリテラル \\ として保持', () => {
+    expect(parseValueList('foo\\')).toEqual(['foo\\']);
+  });
+
+  it('連続したエスケープ', () => {
+    expect(parseValueList('\\,\\,')).toEqual([',,']);
+  });
+});

--- a/extension/webview/components/RuleEditor.tsx
+++ b/extension/webview/components/RuleEditor.tsx
@@ -8,6 +8,7 @@ import type {
   TemplateSequenceRule,
   ValueListRule,
 } from '../../src/mock/rules.js';
+import { parseValueList, serializeValueList } from '../../src/mock/valueList.js';
 
 export type RuleKind = Rule['kind'];
 
@@ -253,19 +254,13 @@ function ValueListEditor({
   rule: ValueListRule;
   onChange: (r: Rule) => void;
 }) {
-  const text = rule.values.map((v) => (v === null ? '' : String(v))).join(', ');
+  const text = serializeValueList(rule.values);
   return (
     <div className="editor-inline">
       <TextField
-        label="値（カンマ区切り）"
+        label="値（カンマ区切り / \\, でコンマ、\\\\ で \\ をエスケープ）"
         value={text}
-        onChange={(next) => {
-          const values = next
-            .split(',')
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-          onChange({ ...rule, values });
-        }}
+        onChange={(next) => onChange({ ...rule, values: parseValueList(next) })}
         wide
       />
     </div>


### PR DESCRIPTION
## Summary

カラムルールの値リスト編集欄でコンマ (`,`) を含む値が入力できなかった問題を修正。

- 入力欄を `\,` でコンマ、`\\` でバックスラッシュをエスケープできる仕様に変更
- パース/シリアライズを純関数 `parseValueList` / `serializeValueList` として `src/mock/valueList.ts` に切り出し
- 再現テストを 12 件追加（コンマを含む値の保持、ラウンドトリップ、エスケープ詳細、既存挙動の維持）

### 例

| 入力 | 結果 |
|---|---|
| `hello\, world, foo` | `["hello, world", "foo"]` |
| `\,\,` | `[",,"]` |
| `a\\, b` | `["a\\", "b"]`（バックスラッシュ＋区切り）|

## Test plan

- [x] `npm test` 全 87 テスト通過
- [x] `npm run typecheck` 両 tsconfig でエラーなし
- [x] `npm run build` 成功
- [ ] F5 起動後、値リストルールに `hello\, world, foo` を入力し、プレビュー値が `hello, world` または `foo` のみになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)