### PR TITLE
値リスト入力欄でエスケープ \, が書き戻されるバグを修正

### DIFF
--- a/extension/test/valueList.test.ts
+++ b/extension/test/valueList.test.ts
@@ -44,6 +44,65 @@ describe('parseValueList - 既存挙動の維持', () => {
   });
 });
 
+describe('Issue reproduction: controlled-input ラウンドトリップで \\, が入力できない', () => {
+  // parseValueList / serializeValueList は単体では正しい。
+  // 問題は React の controlled <input> が onChange 毎に serialize(parse(text)) を走らせていたこと:
+  //   1. ユーザが `\` を 1 文字入力 → parse → ['\\'] → serialize → '\\\\' (=表示は \\) と書き戻される
+  //   2. 続けて `,` を入力 → 入力欄は `\\,` → parse → ['\\'] → 続く `,` は区切りとして消費される
+  //   3. 結果としてユーザは `\,` エスケープ列を画面に作れず、コンマ値も作れない
+  //
+  // 修正: ValueListEditor が raw text を local state に保持し、parse は親への onChange 計算のみに使う。
+  //       serialize は初期表示の 1 回だけ。
+
+  // 修正前の挙動を模倣
+  const simulateOld = (typing: string) => {
+    let display = '';
+    let values: string[] = [];
+    for (const ch of typing) {
+      const newInput = display + ch;
+      values = parseValueList(newInput);
+      display = serializeValueList(values); // ← 往復書き戻し (バグ原因)
+    }
+    return { display, values };
+  };
+
+  // 修正後の挙動を模倣 (text を local state に保持)
+  const simulateNew = (typing: string) => {
+    let text = '';
+    let values: string[] = [];
+    for (const ch of typing) {
+      text = text + ch;
+      values = parseValueList(text); // text は書き戻さない
+    }
+    return { text, values };
+  };
+
+  it('修正前: \\, とタイプしてもリテラルコンマ値を作れない (バグ再現)', () => {
+    const r = simulateOld('\\,');
+    expect(r.values).not.toEqual([',']);
+    expect(r.values).toEqual(['\\']);
+    expect(r.display).toBe('\\\\');
+  });
+
+  it('修正後: \\, とタイプするとリテラル "," が単一値として得られる', () => {
+    const r = simulateNew('\\,');
+    expect(r.text).toBe('\\,');
+    expect(r.values).toEqual([',']);
+  });
+
+  it('修正後: コンマを含む複数値もエスケープを保ちつつ正しく解釈される', () => {
+    const r = simulateNew('hello\\, world, foo');
+    expect(r.text).toBe('hello\\, world, foo');
+    expect(r.values).toEqual(['hello, world', 'foo']);
+  });
+
+  it('修正後: 単独 \\ のままでも text に保持されエスケープを継続入力できる', () => {
+    const r = simulateNew('\\');
+    expect(r.text).toBe('\\');
+    expect(r.values).toEqual(['\\']); // 未閉のエスケープは parser がリテラル \ として扱う
+  });
+});
+
 describe('parseValueList - バックスラッシュエスケープの詳細', () => {
   it('\\\\ はリテラル \\ になる', () => {
     expect(parseValueList('a\\\\b')).toEqual(['a\\b']);

--- a/extension/webview/components/RuleEditor.tsx
+++ b/extension/webview/components/RuleEditor.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type {
   DateRangeRule,
   FormatRule,
@@ -254,13 +255,19 @@ function ValueListEditor({
   rule: ValueListRule;
   onChange: (r: Rule) => void;
 }) {
-  const text = serializeValueList(rule.values);
+  // raw text を local state に保持。serialize は初期表示の 1 回のみ。
+  // 親への onChange では parse 結果を渡すが、text を serialize で書き戻さないため
+  // 入力途中の \ が \\ にすり替わる問題を回避する。
+  const [text, setText] = useState(() => serializeValueList(rule.values));
   return (
     <div className="editor-inline">
       <TextField
         label="値（カンマ区切り / \\, でコンマ、\\\\ で \\ をエスケープ）"
         value={text}
-        onChange={(next) => onChange({ ...rule, values: parseValueList(next) })}
+        onChange={(next) => {
+          setText(next);
+          onChange({ ...rule, values: parseValueList(next) });
+        }}
         wide
       />
     </div>


### PR DESCRIPTION
## Summary

#5 の続報。値リスト入力欄に `\,` を入力してもリテラルコンマ値を作れない問題を修正。

### 原因

`ValueListEditor` が controlled `<input>` として毎 onChange 毎に `serialize(parseValueList(text))` で text を書き戻していたため、入力途中の単独 `\` が `\\` に変換されてしまい、続く `,` が区切りとして消費されてエスケープ列を画面に作れなかった。`parseValueList` / `serializeValueList` 単体は正しく、UI 層の往復が原因。

### 修正

`useState` で raw text を保持し、`parseValueList` は親への `onChange` に渡す `values` 計算のみに使用。`serializeValueList` は初期表示の 1 回だけ呼ぶ。

### テスト

旧/新エディタ挙動を模した simulation 形式で再現テストを 4 件追加（`Issue reproduction: controlled-input ラウンドトリップで \\, が入力できない`）。

- 旧挙動: `\,` 入力 → `['\\']` （バグ）
- 新挙動: `\,` 入力 → `[',']` （期待通り）
- `hello\, world, foo` → `['hello, world', 'foo']`
- 単独 `\` も text に保持されエスケープ継続入力可能

## Test plan

- [x] `npm test` 全 91 テスト通過
- [x] `npm run typecheck` 両 tsconfig でエラーなし
- [x] `npm run build` 成功
- [ ] F5 起動後、値リストルールに `hello\, world, foo` を入力 → プレビュー値が `hello, world` または `foo` になることを確認
- [ ] `\,` 単独入力 → 単一値 `,` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)