### PR TITLE
時刻 / タイムスタンプ範囲ルール追加 + 日付範囲のステップ単位対応

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -16,7 +16,10 @@ PostgreSQL の `CREATE TABLE` DDL から、カラム別ルールに基づいた�
 - **フォーマット指定**: `{...}` 内のみフォーマット指定として解釈、外側は一般リテラル
   - 文字種: `A`=英大 / `a`=英小 / `9`=数字 / `X`=英数 / `H`=ひらがな / `K`=カタカナ / `S`=記号
   - 例: `{AAA}-{9999}` → `ABC-1234`、`PRE{A}-{99}` → `PREB-42`、`A-{9}` → `A-3`（先頭 `A` はリテラル）
-- **数値範囲 / 日付範囲**: 生成モード（ランダム / シーケンス増 / シーケンス減）を選択。シーケンス時はステップ幅を指定し、`[min, max]` を超えると循環する
+- **数値範囲**: 生成モード（ランダム / シーケンス増 / シーケンス減）を選択。シーケンス時はステップ幅を指定し、`[min, max]` を超えると循環する
+- **日付範囲**: モード + ステップ + 単位（日 / 月 / 年）。月単位での日末は次月最終日に clamp（例: `2026-01-31` + 1ヶ月 → `2026-02-28`）
+- **時刻範囲**: `HH:MM:SS` の min/max。モード + ステップ + 単位（秒 / 分 / 時）
+- **タイムスタンプ範囲**: `YYYY-MM-DDTHH:MM:SS` の min/max。モード + ステップ + 単位（秒 / 分 / 時 / 日）。生成値は `YYYY-MM-DD HH:MM:SS`
 - **値リスト**: カンマ区切り。値内のコンマは `\,`、リテラル `\` は `\\` でエスケープ
 
 ## インストール
@@ -26,17 +29,23 @@ PostgreSQL の `CREATE TABLE` DDL から、カラム別ルールに基づいた�
 1. リリース成果物（または社内配布された）`mock-data-generator-extension-<version>.vsix` を入手
 2. 以下のいずれかの方法でインストール:
 
-   **コマンドラインから**
-   ```bash
-   code --install-extension mock-data-generator-extension-<version>.vsix
-   ```
+**VSCodeからPATHにコマンドを追加:** (未インストールの場合のみ実施)
+  1. VSCodeを起動
+  2. Windows: **`Ctrl+Shift+P`** または **`F1`** , MacOS: **`Cmd+Shift+P`**
+  3. **`shell command`** と入力
+  4. **`Shell Command: Install 'code' command in PATH`** を選択して実行
 
-   **VSCode UI から**
-   - Extensions パネル（`Cmd+Shift+X`）を開く
-   - 右上の `...` メニュー → `Install from VSIX...`
-   - 受け取った `.vsix` ファイルを選択
+**コマンドラインから:**
+  ```bash
+  code --install-extension mock-data-generator-extension-<version>.vsix
+  ```
 
-3. インストール後、VSCode を再読み込み（`Developer: Reload Window`）
+**VSCode UI から:**
+  - Extensions パネル（Windows: `Ctrl+Shift+X` , MacOS: `Cmd+Shift+X`）を開く
+  - 右上の `...` メニュー → `Install from VSIX...`
+  - 受け取った `.vsix` ファイルを選択
+
+1. インストール後、VSCode を再読み込み（`Developer: Reload Window`）
 
 ### B. ソースからビルドしてインストール
 
@@ -50,7 +59,7 @@ code --install-extension dist/mock-data-generator-extension-*.vsix
 
 ## 使い方
 
-1. コマンドパレット（`Cmd+Shift+P`）から **`Mock Data Generator: Open`** を実行 → WebView パネルが開く
+1. コマンドパレット（Windows: `Ctrl+Shift+P` , MacOS: `Cmd+Shift+P`）から **`Mock Data Generator: Open`** を実行 → WebView パネルが開く
 2. **DDL を貼付** または **ファイルを選択** → 「DDL を解析」をクリック
 3. **カラム別ルール設定**でカラムごとに生成ルールを選択・調整
 4. **件数**を入力して「モックデータ生成」

--- a/extension/src/mock/generator.ts
+++ b/extension/src/mock/generator.ts
@@ -1,5 +1,10 @@
 import type { Column } from '../ddl/types.js';
-import type { Rule } from './rules.js';
+import type {
+  DateRangeRule,
+  Rule,
+  TimeRangeRule,
+  TimestampRangeRule,
+} from './rules.js';
 import { TEMPLATE_PLACEHOLDER } from './rules.js';
 
 export type RawValue = string | number | boolean | null;
@@ -81,6 +86,10 @@ function valueFor(col: Column, rule: Rule, rowIdx: number, rng: Rng): RawValue {
       return numberFromRange(rule, rowIdx, rng);
     case 'date_range':
       return dateFromRange(rule, rowIdx, rng);
+    case 'time_range':
+      return timeFromRange(rule, rowIdx, rng);
+    case 'timestamp_range':
+      return timestampFromRange(rule, rowIdx, rng);
     case 'value_list': {
       if (rule.values.length === 0) return null;
       return rule.values[rng.nextInt(rule.values.length)] ?? null;
@@ -190,31 +199,155 @@ function numberFromRange(
   return Math.round(raw * factor) / factor;
 }
 
-function dateFromRange(
-  rule: { min: string; max: string; mode: 'random' | 'increment' | 'decrement'; step?: number },
-  rowIdx: number,
-  rng: Rng,
-): string {
+function dateFromRange(rule: DateRangeRule, rowIdx: number, rng: Rng): string {
   const MS_PER_DAY = 86_400_000;
   const minMs = Date.parse(rule.min);
   const maxMs = Date.parse(rule.max);
-  const [lo, hi] = minMs <= maxMs ? [minMs, maxMs] : [maxMs, minMs];
+  const [loMs, hiMs] = minMs <= maxMs ? [minMs, maxMs] : [maxMs, minMs];
   if (rule.mode === 'random') {
-    const span = hi - lo;
-    const pickMs = lo + Math.floor(rng.nextFloat() * (span + 1));
+    const span = hiMs - loMs;
+    const pickMs = loMs + Math.floor(rng.nextFloat() * (span + 1));
     return toIsoDate(pickMs);
   }
-  const stepDays = Math.max(1, Math.floor(rule.step ?? 1));
-  const spanDays = Math.floor((hi - lo) / MS_PER_DAY);
-  const slots = Math.floor(spanDays / stepDays) + 1;
+  const step = Math.max(1, Math.floor(rule.step ?? 1));
+  const unit = rule.stepUnit ?? 'days';
+  const lo = new Date(loMs);
+  const hi = new Date(hiMs);
+  if (unit === 'days') {
+    const spanDays = Math.floor((hiMs - loMs) / MS_PER_DAY);
+    const slots = Math.floor(spanDays / step) + 1;
+    const idx = rowIdx % slots;
+    const target = rule.mode === 'increment' ? addDays(lo, idx * step) : addDays(hi, -idx * step);
+    return toIsoDate(target.getTime());
+  }
+  if (unit === 'months') {
+    const loYM = lo.getUTCFullYear() * 12 + lo.getUTCMonth();
+    const hiYM = hi.getUTCFullYear() * 12 + hi.getUTCMonth();
+    const slots = Math.floor((hiYM - loYM) / step) + 1;
+    const idx = rowIdx % slots;
+    const target = rule.mode === 'increment' ? addMonths(lo, idx * step) : addMonths(hi, -idx * step);
+    return toIsoDate(target.getTime());
+  }
+  // years
+  const slots = Math.floor((hi.getUTCFullYear() - lo.getUTCFullYear()) / step) + 1;
   const idx = rowIdx % slots;
-  const offsetMs = idx * stepDays * MS_PER_DAY;
-  const ms = rule.mode === 'increment' ? lo + offsetMs : hi - offsetMs;
-  return toIsoDate(ms);
+  const target = rule.mode === 'increment' ? addYears(lo, idx * step) : addYears(hi, -idx * step);
+  return toIsoDate(target.getTime());
 }
+
+function timeFromRange(rule: TimeRangeRule, rowIdx: number, rng: Rng): string {
+  const minSec = hmsToSeconds(rule.min);
+  const maxSec = hmsToSeconds(rule.max);
+  const [lo, hi] = minSec <= maxSec ? [minSec, maxSec] : [maxSec, minSec];
+  if (rule.mode === 'random') {
+    const pick = lo + Math.floor(rng.nextFloat() * (hi - lo + 1));
+    return secondsToHms(pick);
+  }
+  const unitSec = TIME_UNIT_SECONDS[rule.stepUnit ?? 'seconds'];
+  const stepSec = Math.max(1, Math.floor(rule.step ?? 1) * unitSec);
+  const slots = Math.floor((hi - lo) / stepSec) + 1;
+  const idx = rowIdx % slots;
+  const offset = idx * stepSec;
+  const sec = rule.mode === 'increment' ? lo + offset : hi - offset;
+  return secondsToHms(sec);
+}
+
+function timestampFromRange(
+  rule: TimestampRangeRule,
+  rowIdx: number,
+  rng: Rng,
+): string {
+  const minMs = parseDatetimeLocal(rule.min);
+  const maxMs = parseDatetimeLocal(rule.max);
+  const [lo, hi] = minMs <= maxMs ? [minMs, maxMs] : [maxMs, minMs];
+  if (rule.mode === 'random') {
+    const pick = lo + Math.floor(rng.nextFloat() * (hi - lo + 1));
+    return formatTimestamp(pick);
+  }
+  const unitMs = TIMESTAMP_UNIT_MS[rule.stepUnit ?? 'seconds'];
+  const stepMs = Math.max(1, Math.floor(rule.step ?? 1) * unitMs);
+  const slots = Math.floor((hi - lo) / stepMs) + 1;
+  const idx = rowIdx % slots;
+  const offset = idx * stepMs;
+  const ms = rule.mode === 'increment' ? lo + offset : hi - offset;
+  return formatTimestamp(ms);
+}
+
+const TIME_UNIT_SECONDS = { seconds: 1, minutes: 60, hours: 3600 } as const;
+const TIMESTAMP_UNIT_MS = {
+  seconds: 1000,
+  minutes: 60_000,
+  hours: 3_600_000,
+  days: 86_400_000,
+} as const;
 
 function toIsoDate(ms: number): string {
   return new Date(ms).toISOString().slice(0, 10);
+}
+
+function formatTimestamp(ms: number): string {
+  const iso = new Date(ms).toISOString();
+  return `${iso.slice(0, 10)} ${iso.slice(11, 19)}`;
+}
+
+// `YYYY-MM-DDTHH:MM:SS` または `YYYY-MM-DD HH:MM:SS` を UTC ms として解釈。
+// HTML <input type="datetime-local"> の値はタイムゾーン情報を持たないため、
+// Date.parse は実行環境のローカル TZ で解釈してしまう。ここでは wall-clock を
+// そのまま保持するため UTC として扱う。
+function parseDatetimeLocal(s: string): number {
+  const [datePart = '', timePart = '00:00:00'] = s.split(/[T ]/);
+  const [y, mo, d] = datePart.split('-').map((p) => Number(p));
+  const [h, mi, se] = timePart.split(':').map((p) => Number(p));
+  return Date.UTC(y ?? 1970, (mo ?? 1) - 1, d ?? 1, h ?? 0, mi ?? 0, se ?? 0);
+}
+
+function hmsToSeconds(hms: string): number {
+  const [h, m, s] = hms.split(':').map((p) => Number(p));
+  return (h ?? 0) * 3600 + (m ?? 0) * 60 + (s ?? 0);
+}
+
+function secondsToHms(totalSeconds: number): string {
+  const s = ((totalSeconds % 86400) + 86400) % 86400;
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return `${pad2(h)}:${pad2(m)}:${pad2(sec)}`;
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function addDays(d: Date, n: number): Date {
+  const copy = new Date(d.getTime());
+  copy.setUTCDate(d.getUTCDate() + n);
+  return copy;
+}
+
+function addMonths(d: Date, n: number): Date {
+  const year = d.getUTCFullYear();
+  const month = d.getUTCMonth() + n;
+  const day = d.getUTCDate();
+  const targetYear = year + Math.floor(month / 12);
+  const targetMonth = ((month % 12) + 12) % 12;
+  // clamp day to last day of target month
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+  const finalDay = Math.min(day, lastDay);
+  return new Date(
+    Date.UTC(
+      targetYear,
+      targetMonth,
+      finalDay,
+      d.getUTCHours(),
+      d.getUTCMinutes(),
+      d.getUTCSeconds(),
+      d.getUTCMilliseconds(),
+    ),
+  );
+}
+
+function addYears(d: Date, n: number): Date {
+  return addMonths(d, n * 12);
 }
 
 function defaultForColumn(col: Column, rng: Rng): RawValue {

--- a/extension/src/mock/rules.ts
+++ b/extension/src/mock/rules.ts
@@ -31,12 +31,37 @@ export type NumberRangeRule = {
   step?: number;
 };
 
+export type DateStepUnit = 'days' | 'months' | 'years';
+
 export type DateRangeRule = {
   kind: 'date_range';
   min: string;
   max: string;
   mode: RangeMode;
   step?: number;
+  stepUnit?: DateStepUnit;
+};
+
+export type TimeStepUnit = 'seconds' | 'minutes' | 'hours';
+
+export type TimeRangeRule = {
+  kind: 'time_range';
+  min: string;
+  max: string;
+  mode: RangeMode;
+  step?: number;
+  stepUnit?: TimeStepUnit;
+};
+
+export type TimestampStepUnit = 'seconds' | 'minutes' | 'hours' | 'days';
+
+export type TimestampRangeRule = {
+  kind: 'timestamp_range';
+  min: string;
+  max: string;
+  mode: RangeMode;
+  step?: number;
+  stepUnit?: TimestampStepUnit;
 };
 
 export type ValueListRule = {
@@ -54,6 +79,8 @@ export type Rule =
   | FormatRule
   | NumberRangeRule
   | DateRangeRule
+  | TimeRangeRule
+  | TimestampRangeRule
   | ValueListRule
   | DefaultRule;
 

--- a/extension/test/generator.test.ts
+++ b/extension/test/generator.test.ts
@@ -566,3 +566,368 @@ describe('Issue #4 reproduction: 数値範囲/日付範囲のmode (random/increm
     });
   });
 });
+
+describe('generate - date_range rule with step units (months / years)', () => {
+  it('stepUnit=months: 月単位でインクリメント', () => {
+    const rows = generate([col('d', 'date')], 4, {
+      rules: {
+        d: {
+          kind: 'date_range',
+          min: '2026-01-15',
+          max: '2026-12-15',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'months',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-01-15',
+      '2026-02-15',
+      '2026-03-15',
+      '2026-04-15',
+    ]);
+  });
+
+  it('stepUnit=months: 月末は次月の最終日に clamp', () => {
+    const rows = generate([col('d', 'date')], 4, {
+      rules: {
+        d: {
+          kind: 'date_range',
+          min: '2026-01-31',
+          max: '2026-04-30',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'months',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-01-31',
+      '2026-02-28',
+      '2026-03-31',
+      '2026-04-30',
+    ]);
+  });
+
+  it('stepUnit=years: 年単位でインクリメント', () => {
+    const rows = generate([col('d', 'date')], 4, {
+      rules: {
+        d: {
+          kind: 'date_range',
+          min: '2026-06-01',
+          max: '2030-06-01',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'years',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-06-01',
+      '2027-06-01',
+      '2028-06-01',
+      '2029-06-01',
+    ]);
+  });
+
+  it('stepUnit=months で wrap', () => {
+    const rows = generate([col('d', 'date')], 5, {
+      rules: {
+        d: {
+          kind: 'date_range',
+          min: '2026-01-15',
+          max: '2026-03-15',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'months',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-01-15',
+      '2026-02-15',
+      '2026-03-15',
+      '2026-01-15',
+      '2026-02-15',
+    ]);
+  });
+
+  it('stepUnit=months, mode=decrement: 月単位で減算', () => {
+    const rows = generate([col('d', 'date')], 4, {
+      rules: {
+        d: {
+          kind: 'date_range',
+          min: '2026-01-15',
+          max: '2026-04-15',
+          mode: 'decrement',
+          step: 1,
+          stepUnit: 'months',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-04-15',
+      '2026-03-15',
+      '2026-02-15',
+      '2026-01-15',
+    ]);
+  });
+
+  it('stepUnit 未指定の既存ルールは日単位として動作（後方互換）', () => {
+    const rows = generate([col('d', 'date')], 3, {
+      rules: {
+        d: {
+          kind: 'date_range',
+          min: '2026-01-01',
+          max: '2026-01-31',
+          mode: 'increment',
+          step: 1,
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-01-01',
+      '2026-01-02',
+      '2026-01-03',
+    ]);
+  });
+});
+
+describe('generate - time_range rule', () => {
+  it('random mode: 全行が HH:MM:SS で [min,max] 内', () => {
+    const rows = generate([col('t', 'time')], 30, {
+      rules: {
+        t: {
+          kind: 'time_range',
+          min: '09:00:00',
+          max: '17:00:00',
+          mode: 'random',
+        },
+      },
+      rng: new Mulberry32(7),
+    });
+    for (const r of rows) {
+      const v = r[0] as string;
+      expect(v).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+      expect(v >= '09:00:00').toBe(true);
+      expect(v <= '17:00:00').toBe(true);
+    }
+  });
+
+  it('increment stepUnit=seconds', () => {
+    const rows = generate([col('t', 'time')], 3, {
+      rules: {
+        t: {
+          kind: 'time_range',
+          min: '00:00:00',
+          max: '00:00:10',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'seconds',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual(['00:00:00', '00:00:01', '00:00:02']);
+  });
+
+  it('increment stepUnit=minutes', () => {
+    const rows = generate([col('t', 'time')], 4, {
+      rules: {
+        t: {
+          kind: 'time_range',
+          min: '12:00:00',
+          max: '12:05:00',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'minutes',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '12:00:00',
+      '12:01:00',
+      '12:02:00',
+      '12:03:00',
+    ]);
+  });
+
+  it('increment stepUnit=hours', () => {
+    const rows = generate([col('t', 'time')], 4, {
+      rules: {
+        t: {
+          kind: 'time_range',
+          min: '00:00:00',
+          max: '06:00:00',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'hours',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '00:00:00',
+      '01:00:00',
+      '02:00:00',
+      '03:00:00',
+    ]);
+  });
+
+  it('decrement stepUnit=hours', () => {
+    const rows = generate([col('t', 'time')], 3, {
+      rules: {
+        t: {
+          kind: 'time_range',
+          min: '00:00:00',
+          max: '03:00:00',
+          mode: 'decrement',
+          step: 1,
+          stepUnit: 'hours',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual(['03:00:00', '02:00:00', '01:00:00']);
+  });
+
+  it('increment で wrap', () => {
+    const rows = generate([col('t', 'time')], 5, {
+      rules: {
+        t: {
+          kind: 'time_range',
+          min: '00:00:00',
+          max: '00:00:02',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'seconds',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '00:00:00',
+      '00:00:01',
+      '00:00:02',
+      '00:00:00',
+      '00:00:01',
+    ]);
+  });
+});
+
+describe('generate - timestamp_range rule', () => {
+  it('random mode: 全行が YYYY-MM-DD HH:MM:SS 形式かつ範囲内', () => {
+    const rows = generate([col('ts', 'timestamp')], 20, {
+      rules: {
+        ts: {
+          kind: 'timestamp_range',
+          min: '2026-01-01T00:00:00',
+          max: '2026-01-31T23:59:59',
+          mode: 'random',
+        },
+      },
+      rng: new Mulberry32(13),
+    });
+    for (const r of rows) {
+      const v = r[0] as string;
+      expect(v).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+      expect(v >= '2026-01-01 00:00:00').toBe(true);
+      expect(v <= '2026-01-31 23:59:59').toBe(true);
+    }
+  });
+
+  it('increment stepUnit=hours', () => {
+    const rows = generate([col('ts', 'timestamp')], 4, {
+      rules: {
+        ts: {
+          kind: 'timestamp_range',
+          min: '2026-01-01T00:00:00',
+          max: '2026-01-01T05:00:00',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'hours',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-01-01 00:00:00',
+      '2026-01-01 01:00:00',
+      '2026-01-01 02:00:00',
+      '2026-01-01 03:00:00',
+    ]);
+  });
+
+  it('increment stepUnit=days', () => {
+    const rows = generate([col('ts', 'timestamp')], 3, {
+      rules: {
+        ts: {
+          kind: 'timestamp_range',
+          min: '2026-01-01T12:30:00',
+          max: '2026-01-05T12:30:00',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'days',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-01-01 12:30:00',
+      '2026-01-02 12:30:00',
+      '2026-01-03 12:30:00',
+    ]);
+  });
+
+  it('decrement stepUnit=hours', () => {
+    const rows = generate([col('ts', 'timestamp')], 3, {
+      rules: {
+        ts: {
+          kind: 'timestamp_range',
+          min: '2026-01-01T00:00:00',
+          max: '2026-01-01T02:00:00',
+          mode: 'decrement',
+          step: 1,
+          stepUnit: 'hours',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-01-01 02:00:00',
+      '2026-01-01 01:00:00',
+      '2026-01-01 00:00:00',
+    ]);
+  });
+
+  it('increment で wrap', () => {
+    const rows = generate([col('ts', 'timestamp')], 5, {
+      rules: {
+        ts: {
+          kind: 'timestamp_range',
+          min: '2026-01-01T00:00:00',
+          max: '2026-01-01T00:00:02',
+          mode: 'increment',
+          step: 1,
+          stepUnit: 'seconds',
+        },
+      },
+      rng: new Mulberry32(1),
+    });
+    expect(rows.map((r) => r[0])).toEqual([
+      '2026-01-01 00:00:00',
+      '2026-01-01 00:00:01',
+      '2026-01-01 00:00:02',
+      '2026-01-01 00:00:00',
+      '2026-01-01 00:00:01',
+    ]);
+  });
+});

--- a/extension/webview/components/ColumnRuleTable.tsx
+++ b/extension/webview/components/ColumnRuleTable.tsx
@@ -15,6 +15,8 @@ const RULE_KIND_LABELS: Record<RuleKind, string> = {
   format: 'フォーマット指定',
   number_range: '数値範囲',
   date_range: '日付範囲',
+  time_range: '時刻範囲',
+  timestamp_range: 'タイムスタンプ範囲',
   value_list: '値リスト',
 };
 
@@ -106,6 +108,16 @@ function detectConflict(col: Column, rule: Rule): string | null {
     case 'date_range':
       if (!dateTypes.includes(baseType)) {
         return `日付範囲は日付型に推奨（現在の型: ${col.dataType}）`;
+      }
+      return null;
+    case 'time_range':
+      if (!['time', 'timestamp'].includes(baseType)) {
+        return `時刻範囲は time / timestamp 型に推奨（現在の型: ${col.dataType}）`;
+      }
+      return null;
+    case 'timestamp_range':
+      if (baseType !== 'timestamp') {
+        return `タイムスタンプ範囲は timestamp 型に推奨（現在の型: ${col.dataType}）`;
       }
       return null;
     case 'format':

--- a/extension/webview/components/RuleEditor.tsx
+++ b/extension/webview/components/RuleEditor.tsx
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 import type {
   DateRangeRule,
+  DateStepUnit,
   FormatRule,
   NumberRangeRule,
   RangeMode,
   Rule,
   SequenceRule,
   TemplateSequenceRule,
+  TimeRangeRule,
+  TimeStepUnit,
+  TimestampRangeRule,
+  TimestampStepUnit,
   ValueListRule,
 } from '../../src/mock/rules.js';
 import { parseValueList, serializeValueList } from '../../src/mock/valueList.js';
@@ -37,6 +42,25 @@ export function defaultRuleForKind(kind: RuleKind): Rule {
         max: '2026-12-31',
         mode: 'random',
         step: 1,
+        stepUnit: 'days',
+      };
+    case 'time_range':
+      return {
+        kind: 'time_range',
+        min: '00:00:00',
+        max: '23:59:59',
+        mode: 'random',
+        step: 1,
+        stepUnit: 'seconds',
+      };
+    case 'timestamp_range':
+      return {
+        kind: 'timestamp_range',
+        min: '2026-01-01T00:00:00',
+        max: '2026-12-31T23:59:59',
+        mode: 'random',
+        step: 1,
+        stepUnit: 'seconds',
       };
     case 'value_list':
       return { kind: 'value_list', values: [] };
@@ -62,6 +86,10 @@ export function RuleEditor({ rule, onChange }: Props) {
       return <NumberRangeEditor rule={rule} onChange={onChange} />;
     case 'date_range':
       return <DateRangeEditor rule={rule} onChange={onChange} />;
+    case 'time_range':
+      return <TimeRangeEditor rule={rule} onChange={onChange} />;
+    case 'timestamp_range':
+      return <TimestampRangeEditor rule={rule} onChange={onChange} />;
     case 'value_list':
       return <ValueListEditor rule={rule} onChange={onChange} />;
     case 'default':
@@ -238,13 +266,160 @@ function DateRangeEditor({
         onChange={(mode) => onChange({ ...rule, mode })}
       />
       {rule.mode !== 'random' && (
-        <NumberField
-          label="ステップ（日）"
-          value={rule.step ?? 1}
-          onChange={(step) => onChange({ ...rule, step })}
-        />
+        <>
+          <NumberField
+            label="ステップ"
+            value={rule.step ?? 1}
+            onChange={(step) => onChange({ ...rule, step })}
+          />
+          <StepUnitField<DateStepUnit>
+            value={rule.stepUnit ?? 'days'}
+            options={DATE_STEP_UNIT_OPTIONS}
+            onChange={(stepUnit) => onChange({ ...rule, stepUnit })}
+          />
+        </>
       )}
     </div>
+  );
+}
+
+function TimeRangeEditor({
+  rule,
+  onChange,
+}: {
+  rule: TimeRangeRule;
+  onChange: (r: Rule) => void;
+}) {
+  return (
+    <div className="editor-inline">
+      <label className="field">
+        <span>最小</span>
+        <input
+          type="time"
+          step={1}
+          value={rule.min}
+          onChange={(e) => onChange({ ...rule, min: e.target.value })}
+        />
+      </label>
+      <label className="field">
+        <span>最大</span>
+        <input
+          type="time"
+          step={1}
+          value={rule.max}
+          onChange={(e) => onChange({ ...rule, max: e.target.value })}
+        />
+      </label>
+      <RangeModeField
+        mode={rule.mode}
+        onChange={(mode) => onChange({ ...rule, mode })}
+      />
+      {rule.mode !== 'random' && (
+        <>
+          <NumberField
+            label="ステップ"
+            value={rule.step ?? 1}
+            onChange={(step) => onChange({ ...rule, step })}
+          />
+          <StepUnitField<TimeStepUnit>
+            value={rule.stepUnit ?? 'seconds'}
+            options={TIME_STEP_UNIT_OPTIONS}
+            onChange={(stepUnit) => onChange({ ...rule, stepUnit })}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+function TimestampRangeEditor({
+  rule,
+  onChange,
+}: {
+  rule: TimestampRangeRule;
+  onChange: (r: Rule) => void;
+}) {
+  return (
+    <div className="editor-inline">
+      <label className="field">
+        <span>最小</span>
+        <input
+          type="datetime-local"
+          step={1}
+          value={rule.min}
+          onChange={(e) => onChange({ ...rule, min: e.target.value })}
+        />
+      </label>
+      <label className="field">
+        <span>最大</span>
+        <input
+          type="datetime-local"
+          step={1}
+          value={rule.max}
+          onChange={(e) => onChange({ ...rule, max: e.target.value })}
+        />
+      </label>
+      <RangeModeField
+        mode={rule.mode}
+        onChange={(mode) => onChange({ ...rule, mode })}
+      />
+      {rule.mode !== 'random' && (
+        <>
+          <NumberField
+            label="ステップ"
+            value={rule.step ?? 1}
+            onChange={(step) => onChange({ ...rule, step })}
+          />
+          <StepUnitField<TimestampStepUnit>
+            value={rule.stepUnit ?? 'seconds'}
+            options={TIMESTAMP_STEP_UNIT_OPTIONS}
+            onChange={(stepUnit) => onChange({ ...rule, stepUnit })}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+const DATE_STEP_UNIT_OPTIONS: ReadonlyArray<{ value: DateStepUnit; label: string }> = [
+  { value: 'days', label: '日' },
+  { value: 'months', label: '月' },
+  { value: 'years', label: '年' },
+];
+
+const TIME_STEP_UNIT_OPTIONS: ReadonlyArray<{ value: TimeStepUnit; label: string }> = [
+  { value: 'seconds', label: '秒' },
+  { value: 'minutes', label: '分' },
+  { value: 'hours', label: '時' },
+];
+
+const TIMESTAMP_STEP_UNIT_OPTIONS: ReadonlyArray<{ value: TimestampStepUnit; label: string }> = [
+  { value: 'seconds', label: '秒' },
+  { value: 'minutes', label: '分' },
+  { value: 'hours', label: '時' },
+  { value: 'days', label: '日' },
+];
+
+function StepUnitField<U extends string>({
+  value,
+  options,
+  onChange,
+}: {
+  value: U;
+  options: ReadonlyArray<{ value: U; label: string }>;
+  onChange: (u: U) => void;
+}) {
+  return (
+    <label className="field">
+      <span>単位</span>
+      <select value={value} onChange={(e) => onChange(e.target.value as U)}>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
   );
 }
 


### PR DESCRIPTION
## Summary

`date_range` を雛形に時刻・タイムスタンプ型用のルールを追加。さらに3ルール全てで step 単位を選択可能に拡張した。

### 新規ルール

- **`time_range`**: `HH:MM:SS` の min/max、mode (random/increment/decrement)、step + stepUnit (秒/分/時)
- **`timestamp_range`**: `YYYY-MM-DDTHH:MM:SS` の min/max、mode、step + stepUnit (秒/分/時/日)。出力は `YYYY-MM-DD HH:MM:SS`

### date_range 拡張

- `stepUnit?: 'days' | 'months' | 'years'` を追加（既定 `days` で後方互換）
- 月単位の sequence は月末を次月最終日に clamp（例: `2026-01-31` + 1ヶ月 → `2026-02-28`）

### TZ 注意

`<input type=\"datetime-local\">` の値はタイムゾーン情報を持たず、`Date.parse` は実行環境ローカル TZ で解釈する（JST 環境では 9 時間ずれる）。これを避けるため `parseDatetimeLocal` で UTC として明示的に解釈する。

## 変更ファイル

- `src/mock/rules.ts` — 新型・新 stepUnit
- `src/mock/generator.ts` — `dateFromRange` 拡張 + `timeFromRange` / `timestampFromRange` 新規 + `addMonths` / `addYears` ヘルパ
- `webview/components/RuleEditor.tsx` — 新エディタ 2 種 + `StepUnitField<U>` 共通コンポーネント
- `webview/components/ColumnRuleTable.tsx` — ラベル追加 + conflict detection 更新
- `test/generator.test.ts` — 再現テスト 17 件追加
- `README.md` — ルール詳細を更新 + Win/Mac キーバインド整理

## Test plan

- [x] `npm run typecheck` — 両 tsconfig パス
- [x] `npm test` — 全 108 テスト通過（既存 91 + 新規 17）
- [x] `npm run build:prod` — バンドル成功
- [ ] F5 起動 → DDL に `time` / `timestamp` 型を含めて解析:
  - [ ] ルール選択肢に「時刻範囲」「タイムスタンプ範囲」が表示
  - [ ] 各エディタで `<input type=\"time\">` / `<input type=\"datetime-local\">` が動作
  - [ ] 全範囲ルールで increment/decrement 時にステップ + 単位セレクタが表示
  - [ ] `date_range` で `stepUnit=months` 月末 clamp 動作
  - [ ] 生成 SQL を Postgres に投入

🤖 Generated with [Claude Code](https://claude.com/claude-code)