### PR TITLE
README に .vsix 作成手順を明示、ローカル設定をパッケージから除外

### DIFF
--- a/extension/.vscodeignore
+++ b/extension/.vscodeignore
@@ -1,4 +1,5 @@
 .vscode/**
+.claude/**
 src/**
 webview/**
 test/**

--- a/extension/README.md
+++ b/extension/README.md
@@ -57,6 +57,27 @@ npm run package        # → dist/mock-data-generator-extension-<version>.vsix �
 code --install-extension dist/mock-data-generator-extension-*.vsix
 ```
 
+## .vsix の作成（配布用）
+
+社内・チーム向けに `.vsix` を生成して配布する手順:
+
+```bash
+git clone https://github.com/JeonggukLee/mock-data-generator.git
+cd mock-data-generator/extension
+npm install
+npm run package
+```
+
+`npm run package` は内部で `npm run build:prod`（minify ビルド）→ `vsce package --no-dependencies` を実行し、以下のファイルを生成します:
+
+```
+extension/dist/mock-data-generator-extension-<version>.vsix
+```
+
+バージョンは `extension/package.json` の `version` フィールドに依存します。配布時はこのバージョンを更新してから再実行してください。
+
+生成された `.vsix` を「A. `.vsix` ファイルからインストール」の手順で受け取り側に導入できます。
+
 ## 使い方
 
 1. コマンドパレット（Windows: `Ctrl+Shift+P` , MacOS: `Cmd+Shift+P`）から **`Mock Data Generator: Open`** を実行 → WebView パネルが開く

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mock-data-generator-extension",
       "version": "0.0.1",
+      "license": "MIT",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"


### PR DESCRIPTION
## Summary

最新の `.vsix` 生成を実施し、その過程で見つかった以下を修正・整理:

1. **`.vscodeignore`**: `.claude/**` を追加。ローカル限定の Claude 設定が `.vsix` に含まれていたため除外
2. **`extension/README.md`**: 「.vsix の作成（配布用）」セクションを新設。`npm run package` の挙動・出力先・バージョン更新の運用を明示
3. **`extension/package-lock.json`**: license フィールド同期のみ（前回 PR の package.json 変更による npm 自動再同期）

## 生成された .vsix

```
extension/dist/mock-data-generator-extension-0.0.1.vsix
8 files, 63.29 KB
```

含まれるファイル:
- `LICENSE.txt`
- `package.json`
- `readme.md`
- `dist/extension.cjs` (12 KB)
- `dist/webview.css` (6 KB)
- `dist/webview.js` (160 KB)

## Test plan

- [x] `npm run typecheck` パス
- [x] `npm test` 全 108 テスト通過
- [x] `npm run package` で `.vsix` がクリーンに生成される（.claude/.gitignore/*.map なし）
- [ ] 生成 `.vsix` を `code --install-extension` で導入 → 起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)