### PR TITLE
ref ルールの offsetUnit と参照値型のミスマッチを修正

### DIFF
--- a/extension/src/mock/generator.ts
+++ b/extension/src/mock/generator.ts
@@ -374,6 +374,26 @@ function addYears(d: Date, n: number): Date {
   return addMonths(d, n * 12);
 }
 
+type RefValueShape = 'number' | 'date' | 'time' | 'timestamp' | 'unknown';
+
+const REF_COMPATIBLE_UNITS: Record<RefValueShape, ReadonlyArray<RefRule['offsetUnit']>> = {
+  number: ['number'],
+  date: ['days', 'months', 'years'],
+  time: ['seconds', 'minutes', 'hours'],
+  timestamp: ['seconds', 'minutes', 'hours', 'days'],
+  unknown: [],
+};
+
+function detectRefValueShape(v: RawValue): RefValueShape {
+  if (typeof v === 'number') return 'number';
+  if (typeof v !== 'string') return 'unknown';
+  if (/^\d{2}:\d{2}:\d{2}$/.test(v)) return 'time';
+  if (/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}/.test(v)) return 'timestamp';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return 'date';
+  if (v.trim() !== '' && Number.isFinite(Number(v))) return 'number';
+  return 'unknown';
+}
+
 function refValue(rule: RefRule, ctx: GenerateCtx): RawValue {
   if (!ctx.resolved.has(rule.column)) {
     throw new Error(
@@ -390,51 +410,57 @@ function refValue(rule: RefRule, ctx: GenerateCtx): RawValue {
   const [lo, hi] = offsetMin <= offsetMax ? [offsetMin, offsetMax] : [offsetMax, offsetMin];
   const offset = ctx.rng.nextInt(hi - lo + 1) + lo;
   const signed = rule.mode === 'greater' ? offset : -offset;
-  const unit = rule.offsetUnit ?? 'number';
 
-  if (unit === 'number') {
+  // 参照値の実形状を判別し、declared offsetUnit が互換でない場合は形状の既定単位にフォールバック。
+  // これにより UI で参照カラムを切り替えた後に offsetUnit が古いまま残っていても無音で正しく動く。
+  const shape = detectRefValueShape(refRaw);
+  if (shape === 'unknown') {
+    throw new Error(
+      `Reference column "${rule.column}" value "${String(refRaw)}" の形状を解釈できません (数値/日付/時刻/タイムスタンプいずれにも該当せず)`,
+    );
+  }
+  const compatible = REF_COMPATIBLE_UNITS[shape];
+  const unit = rule.offsetUnit && compatible.includes(rule.offsetUnit)
+    ? rule.offsetUnit
+    : compatible[0]!;
+
+  if (shape === 'number') {
     const num = typeof refRaw === 'number' ? refRaw : Number(refRaw);
-    if (!Number.isFinite(num)) {
-      throw new Error(
-        `Reference column "${rule.column}" value is not numeric (got ${String(refRaw)})`,
-      );
-    }
     return num + signed;
   }
 
   const refStr = String(refRaw);
 
-  if (unit === 'days' || unit === 'months' || unit === 'years') {
+  if (shape === 'date') {
     const refMs = Date.parse(refStr);
-    if (!Number.isFinite(refMs)) {
-      throw new Error(`Reference column "${rule.column}" is not a date (got "${refStr}")`);
-    }
     const refDate = new Date(refMs);
     const target =
-      unit === 'days'
-        ? addDays(refDate, signed)
-        : unit === 'months'
-          ? addMonths(refDate, signed)
-          : addYears(refDate, signed);
+      unit === 'months'
+        ? addMonths(refDate, signed)
+        : unit === 'years'
+          ? addYears(refDate, signed)
+          : addDays(refDate, signed); // default for date shape
     return toIsoDate(target.getTime());
   }
 
-  // seconds / minutes / hours
-  const unitSec =
-    unit === 'seconds' ? 1 : unit === 'minutes' ? 60 : 3600;
-  const offsetSec = signed * unitSec;
-
-  // ref is HH:MM:SS time
-  if (/^\d{2}:\d{2}:\d{2}$/.test(refStr)) {
+  if (shape === 'time') {
+    const unitSec =
+      unit === 'hours' ? 3600 : unit === 'minutes' ? 60 : 1; // default seconds
     const refSec = hmsToSeconds(refStr);
-    return secondsToHms(refSec + offsetSec);
+    return secondsToHms(refSec + signed * unitSec);
   }
-  // ref is YYYY-MM-DD HH:MM:SS or ISO timestamp
+
+  // shape === 'timestamp'
+  const unitMs =
+    unit === 'days'
+      ? 86_400_000
+      : unit === 'hours'
+        ? 3_600_000
+        : unit === 'minutes'
+          ? 60_000
+          : 1000; // default seconds
   const refMs = parseDatetimeLocal(refStr.replace(' ', 'T'));
-  if (!Number.isFinite(refMs)) {
-    throw new Error(`Reference column "${rule.column}" is not a timestamp (got "${refStr}")`);
-  }
-  return formatTimestamp(refMs + offsetSec * 1000);
+  return formatTimestamp(refMs + signed * unitMs);
 }
 
 function defaultForColumn(col: Column, rng: Rng): RawValue {

--- a/extension/test/generator.test.ts
+++ b/extension/test/generator.test.ts
@@ -1221,3 +1221,171 @@ describe('generate - format rule with J (Joyo kanji)', () => {
     expect(a).toEqual(b);
   });
 });
+
+describe('Issue reproduction: ref rule offsetUnit と参照値型のミスマッチ', () => {
+  // PR #11 のバグ: offsetUnit が rule に保存された値のまま固定で、参照カラムを切り替えても
+  // UI 表示は allowedUnits の先頭にフォールバックする一方、rule.offsetUnit は古いまま残り、
+  // 計算段で型ミスマッチが起きて throw。
+  //
+  // 修正後は参照値の実形状で計算分岐する。
+
+  it('offsetUnit="number" でも参照値が date 文字列なら days 扱いで計算（無音フォールバック）', () => {
+    const rows = generate(
+      [col('d', 'date'), col('t', 'timestamp')],
+      5,
+      {
+        rules: {
+          d: {
+            kind: 'date_range',
+            min: '2026-02-21',
+            max: '2026-02-21',
+            mode: 'random',
+          },
+          t: {
+            kind: 'ref',
+            column: 'd',
+            mode: 'greater',
+            offsetMin: 1,
+            offsetMax: 1,
+            offsetUnit: 'number',
+          },
+        },
+        rng: new Mulberry32(1),
+      },
+    );
+    // throw せず、ref(2026-02-21) + 1 day = 2026-02-22 が全行で出る
+    for (const r of rows) {
+      expect(r[1]).toBe('2026-02-22');
+    }
+  });
+
+  it('offsetUnit="days" で参照値が number なら number 扱いで計算', () => {
+    const rows = generate(
+      [col('a', 'integer'), col('b', 'integer')],
+      5,
+      {
+        rules: {
+          a: { kind: 'sequence', start: 100, step: 0, zeroPad: false, padWidth: 0 },
+          b: {
+            kind: 'ref',
+            column: 'a',
+            mode: 'greater',
+            offsetMin: 5,
+            offsetMax: 5,
+            offsetUnit: 'days', // mismatched with number value
+          },
+        },
+        rng: new Mulberry32(2),
+      },
+    );
+    for (const r of rows) {
+      expect(r[1]).toBe(105);
+    }
+  });
+
+  it('offsetUnit="seconds" で参照値が date なら days にフォールバック', () => {
+    const rows = generate(
+      [col('d', 'date'), col('d2', 'date')],
+      3,
+      {
+        rules: {
+          d: {
+            kind: 'date_range',
+            min: '2026-03-15',
+            max: '2026-03-15',
+            mode: 'random',
+          },
+          d2: {
+            kind: 'ref',
+            column: 'd',
+            mode: 'greater',
+            offsetMin: 2,
+            offsetMax: 2,
+            offsetUnit: 'seconds', // mismatched with date value
+          },
+        },
+        rng: new Mulberry32(3),
+      },
+    );
+    for (const r of rows) {
+      expect(r[1]).toBe('2026-03-17');
+    }
+  });
+
+  it('整合: offsetUnit="days" で参照値が date なら従来通り', () => {
+    const rows = generate(
+      [col('d', 'date'), col('d2', 'date')],
+      1,
+      {
+        rules: {
+          d: {
+            kind: 'date_range',
+            min: '2026-06-10',
+            max: '2026-06-10',
+            mode: 'random',
+          },
+          d2: {
+            kind: 'ref',
+            column: 'd',
+            mode: 'greater',
+            offsetMin: 3,
+            offsetMax: 3,
+            offsetUnit: 'days',
+          },
+        },
+        rng: new Mulberry32(4),
+      },
+    );
+    expect(rows[0]?.[1]).toBe('2026-06-13');
+  });
+
+  it('整合: offsetUnit="hours" で参照値が timestamp なら従来通り', () => {
+    const rows = generate(
+      [col('ts', 'timestamp'), col('ts2', 'timestamp')],
+      1,
+      {
+        rules: {
+          ts: {
+            kind: 'timestamp_range',
+            min: '2026-04-01T10:00:00',
+            max: '2026-04-01T10:00:00',
+            mode: 'random',
+          },
+          ts2: {
+            kind: 'ref',
+            column: 'ts',
+            mode: 'greater',
+            offsetMin: 2,
+            offsetMax: 2,
+            offsetUnit: 'hours',
+          },
+        },
+        rng: new Mulberry32(5),
+      },
+    );
+    expect(rows[0]?.[1]).toBe('2026-04-01 12:00:00');
+  });
+
+  it('unknown shape: 解釈不能な文字列を参照したら明確に throw', () => {
+    expect(() =>
+      generate(
+        [col('s', 'varchar'), col('s2', 'varchar')],
+        1,
+        {
+          rules: {
+            s: { kind: 'fixed', value: 'hello' },
+            s2: {
+              kind: 'ref',
+              column: 's',
+              mode: 'greater',
+              offsetMin: 1,
+              offsetMax: 1,
+              offsetUnit: 'number',
+            },
+          },
+          rng: new Mulberry32(6),
+        },
+      ),
+    ).toThrow(/解釈できません|cannot be interpreted/);
+  });
+});

--- a/extension/webview/components/RuleEditor.tsx
+++ b/extension/webview/components/RuleEditor.tsx
@@ -450,7 +450,17 @@ function RefEditor({
         <span>参照カラム</span>
         <select
           value={rule.column}
-          onChange={(e) => onChange({ ...rule, column: e.target.value })}
+          onChange={(e) => {
+            const newColumn = e.target.value;
+            const newRefCol = siblings.find((c) => c.name === newColumn);
+            const newBase = (newRefCol?.dataType ?? '').split(/\s+/)[0] ?? '';
+            const newAllowed = unitOptionsForRefType(newBase);
+            const stillValid = newAllowed.some((o) => o.value === rule.offsetUnit);
+            const newUnit = stillValid
+              ? rule.offsetUnit
+              : (newAllowed[0]?.value ?? 'number');
+            onChange({ ...rule, column: newColumn, offsetUnit: newUnit });
+          }}
         >
           <option value="">（選択）</option>
           {siblings.map((c) => (


### PR DESCRIPTION
## Summary

PR #11 の `ref` ルールで、参照先カラムの型と `offsetUnit` が一致しないと `generate` がエラーで停止する不具合を修正。

### 報告された事象

- 参照先 `nyusha_date`: **date** 型（値 `2026-02-21`）
- ソース: **timestamp** 型に `ref` ルール
- エラー: `Generate failed: Error: Reference column "nyusha_date" value is not numeric (got 2026-02-21)`

### 根本原因

`RefEditor` で参照列を切り替えても `rule.offsetUnit` 自体は更新されず、初期既定の `'number'` のまま残るため、参照値が文字列日付なのに数値演算しようとして throw していた（UI 表示の `effectiveUnit` は allowedUnits の先頭にフォールバックするが state には書き戻していなかった）。

### 修正内容

#### 1. `refValue` を value-shape 駆動に変更

`rule.offsetUnit` を盲信せず、参照値の形状を判別してから計算:

- shape: `number` / `date` / `time` / `timestamp` / `unknown`
- declared `offsetUnit` が shape と互換なら使用、不一致なら各 shape の既定単位 (date→days, time→seconds, timestamp→seconds) にフォールバック
- `unknown` は明示的に throw

これで既存の不整合 rule もサイレントに正しく動作。

#### 2. `RefEditor` の防御

参照列を変更した時点で、新 column 型に対する互換 `offsetUnit` を自動選択して `onChange` に渡す（display と state の同期）。

#### 3. 再現テスト 6 件

| ケース | 期待 |
|---|---|
| offsetUnit=number, ref=date | 2026-02-22 (days として動作) |
| offsetUnit=days, ref=number | 105 (number として動作) |
| offsetUnit=seconds, ref=date | 2026-03-17 (days にフォールバック) |
| offsetUnit=days, ref=date | 2026-06-13 (整合維持) |
| offsetUnit=hours, ref=timestamp | 2026-04-01 12:00:00 (整合維持) |
| 解釈不能な文字列 "hello" | throw |

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm test` 全 **128** テスト通過（既存 122 + 新規 6）
- [x] `npm run build` 成功
- [x] `npm run package` `.vsix` 69 KB 生成済
- [x] F5 起動 → ユーザ DDL で再現:
  - [x] 旧 offsetUnit='number' の rule で date 参照しても throw せず動く
  - [x] 参照列切替で単位ドロップダウンが自動更新される

## 既知の振る舞い

- 出力フォーマットは参照値の文字列フォーマットに従う（source カラムの型ではない）
- 例: source=timestamp, ref=date(2026-02-21), +1day → 出力 `2026-02-22`（日付文字列）。Postgres は timestamp 列に date を受け入れるため動作するが時刻は 00:00:00
- 「source 型に合わせた出力フォーマット」が必要になれば別件で拡張

🤖 Generated with [Claude Code](https://claude.com/claude-code)